### PR TITLE
Fix ValueError: hour must be in 0..23 in px100.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 Python software for the Atorch DL24 electronic load.
 
-This project was forked from https://github.com/misdoro/Electronic_load_px100.
+This project was forked from https://github.com/misdoro/Electronic_load_px100 and https://github.com/Jay2k1/Electronic_load_DL24.
+
+## Note: This is a fork for my own use cases/adjustments because [source project](https://github.com/Jay2k1/Electronic_load_DL24) has some limitations to me:
+- Foreground and backgroundcolors of capacity and time measures are black on linux therefore could not be reed.
+- Timer max is 9:59:59
+- Read the timer when it is greater then 23h throws a segmentation fault (Fix ValueError: hour must be in 0..23 in px100.py)
+
+### Changes in this fork
+- Colors of the measures are set to the colors of the DL24 display
+- Timer Bug fixed
+- Set timer max time to 18h 12 min (max int seconds)
 
 # Binary protocol
 

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -131,7 +131,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 ReadHours=int(data.lastval('set_timer').seconds / 3600)
                 # (All Seconds - Hours in seconds) / 60
                 ReadMinutes=int((data.lastval('set_timer').seconds - (ReadHours*3600)) /60)
-                print("TYPE:" +  str(type(data.lastval('set_timer')))+ " ATTR:" + str(dir(data.lastval('set_timer'))) + "HOURS:" + str(ReadHours) +  " MINUTES:" +str(ReadMinutes) )                
+                # print("TYPE:" +  str(type(data.lastval('set_timer')))+ " ATTR:" + str(dir(data.lastval('set_timer'))) + "HOURS:" + str(ReadHours) +  " MINUTES:" +str(ReadMinutes) )                
                 self.set_timer.setTime(QTime(ReadHours,ReadMinutes,0))
             xlim = (time(0), max([time(0, 1, 0), data.lastval('time')]))
             # clear axes

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -11,6 +11,7 @@ from PyQt5.QtCore import (
     QSize,
     QPoint,
     QTimer,
+    QTime,
 )
 
 from PyQt5.QtWidgets import (
@@ -124,7 +125,14 @@ class MainWindow(QtWidgets.QMainWindow):
             self.readTemp.setText("<pre>" + str(int(data.lastval('temp'))) + "°C / " + str(int(data.lastval('temp') * 1.8 + 32)) + "°F</pre>")
             self.Wattage.setText("<pre>{:5.3f} W</pre>".format(power))
             self.readTime.setText("<pre>" + data.lastval('time').strftime("%H:%M:%S") + "</pre>")
-
+            # print("TIMER:"+data.lastval('set_timer').strftime("%H:%M:%S")+" Type:" +str(type(data.lastval('set_timer'))))
+            # Hour and minutes are not correct assigned in data.lastval('set_timer') Hour = Minute, Minute = second. Fix it here.
+            if not self.set_timer.hasFocus():
+                ReadHours=int(data.lastval('set_timer').seconds / 3600)
+                # (All Seconds - Hours in seconds) / 60
+                ReadMinutes=int((data.lastval('set_timer').seconds - (ReadHours*3600)) /60)
+                print("TYPE:" +  str(type(data.lastval('set_timer')))+ " ATTR:" + str(dir(data.lastval('set_timer'))) + "HOURS:" + str(ReadHours) +  " MINUTES:" +str(ReadMinutes) )                
+                self.set_timer.setTime(QTime(ReadHours,ReadMinutes,0))
             xlim = (time(0), max([time(0, 1, 0), data.lastval('time')]))
             # clear axes
             self.ax.cla()

--- a/gui/main.ui
+++ b/gui/main.ui
@@ -166,6 +166,13 @@
                  <height>0</height>
                 </size>
                </property>
+               <property name="maximumTime">
+                <time>
+                 <hour>18</hour>
+                 <minute>12</minute>
+                 <second>00</second>
+                </time>
+               </property>               
                <property name="currentSection">
                 <enum>QDateTimeEdit::HourSection</enum>
                </property>

--- a/gui/main.ui
+++ b/gui/main.ui
@@ -335,7 +335,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid #0000fa; background:#0000fa;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid #0000fa; background:#0000fa;</string>-->
+                <string notr="true">border-radius:0.4em;color: #f8f37e;border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;0.000 V&lt;/pre&gt;</string>
@@ -398,7 +399,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid #fa0000; background:#fa0000;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid #fa0000; background:#fa0000;</string>-->
+                <string notr="true">border-radius:0.4em;color:#96ff79;border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;0.000 A&lt;/pre&gt;</string>
@@ -454,7 +456,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid #008000; background:#008000;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid #008000; background:#008000;</string>-->
+                <string notr="true">border-radius:0.4em;color: #c32c26; border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;0.000 W&lt;/pre&gt;</string>
@@ -518,7 +521,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid #808080; background:#808080;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid #808080; background:#808080;</string>-->
+                <string notr="true">border-radius:0.4em;color:#eeeeee;border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;00°C / 00°F&lt;/pre&gt;</string>
@@ -544,7 +548,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid; background:#000;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid; background:#000;</string>-->
+                <string notr="true">border-radius:0.4em;color:#1ea0e3;border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;0.000 Ah&lt;/pre&gt;</string>
@@ -577,7 +582,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid; background:#000;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid; background:#000;</string>-->
+                <string notr="true">border-radius:0.4em;color:#5b2ae8;border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;0.000 Wh&lt;/pre&gt;</string>
@@ -596,7 +602,8 @@
                 </font>
                </property>
                <property name="styleSheet">
-                <string notr="true">border-radius:0.4em;border:1px solid; background:#000;</string>
+                <!--<string notr="true">border-radius:0.4em;border:1px solid; background:#000;</string>-->
+                <string notr="true">border-radius:0.4em;color: #6aa69b;border:1px solid #000; background:#000;</string>
                </property>
                <property name="text">
                 <string>&lt;pre&gt;00:00:00&lt;/pre&gt;</string>

--- a/instruments/px100.py
+++ b/instruments/px100.py
@@ -4,7 +4,7 @@ written by Mikhail Doronin
 licensed as GPLv3
 """
 
-from datetime import time
+from datetime import time,timedelta
 from math import modf
 from numbers import Number
 from time import sleep
@@ -108,7 +108,7 @@ class PX100(Instrument):
             'temp': 0,
             'set_current': 0.,
             'set_voltage': 0.,
-            'set_timer': time(0),
+            'set_timer': timedelta(0),
         }
 
     def probe(self):
@@ -193,7 +193,8 @@ class PX100(Instrument):
             hh = int(ret[2] / 60)
             mm = ret[2] % 60
             ss = ret[3]
-            return time(hh, mm, ss)  #'{:02d}:{:02d}:{:02d}'.format(hh, mm, ss)
+            # DL24 returns only Minutes and hours for the Timer
+            return timedelta(hours=ret[2], minutes=ret[3])
         else:
             return int.from_bytes(ret[2:5], byteorder='big') / mult
 

--- a/instruments/px100.py
+++ b/instruments/px100.py
@@ -190,10 +190,10 @@ class PX100(Instrument):
             return time(hh, mm, ss)  #'{:02d}:{:02d}:{:02d}'.format(hh, mm, ss)
         elif (command == PX100.TIMER):
             print("Command: "+str(command))
-            hh = int(ret[2] / 60)
-            mm = ret[2] % 60
-            ss = ret[3]
-            # DL24 returns only Minutes and hours for the Timer
+            # hh = int(ret[2] / 60)
+            # mm = ret[2] % 60
+            # ss = ret[3]
+            # DL24 returns only Minutes and hours for the Timer => better datatype = timedelta
             return timedelta(hours=ret[2], minutes=ret[3])
         else:
             return int.from_bytes(ret[2:5], byteorder='big') / mult

--- a/instruments/px100.py
+++ b/instruments/px100.py
@@ -180,9 +180,12 @@ class PX100(Instrument):
             mult = 1000.
 
         if (command == PX100.TIME or command == PX100.TIMER):
-            hh = ret[2]
-            mm = ret[3]
-            ss = ret[4]
+            # hh = ret[2]
+            # mm = ret[3]
+            # ss = ret[4]
+            hh = int(ret[2] / 60)
+            mm = ret[2] % 60
+            ss = ret[3]
             return time(hh, mm, ss)  #'{:02d}:{:02d}:{:02d}'.format(hh, mm, ss)
         else:
             return int.from_bytes(ret[2:5], byteorder='big') / mult

--- a/instruments/px100.py
+++ b/instruments/px100.py
@@ -179,10 +179,17 @@ class PX100(Instrument):
         except:
             mult = 1000.
 
-        if (command == PX100.TIME or command == PX100.TIMER):
+        if (command == PX100.TIME):
             # hh = ret[2]
             # mm = ret[3]
             # ss = ret[4]
+            print("Command: "+str(command))
+            hh = ret[2]
+            mm = ret[3]
+            ss = ret[4]
+            return time(hh, mm, ss)  #'{:02d}:{:02d}:{:02d}'.format(hh, mm, ss)
+        elif (command == PX100.TIMER):
+            print("Command: "+str(command))
             hh = int(ret[2] / 60)
             mm = ret[2] % 60
             ss = ret[3]


### PR DESCRIPTION
Command PX100.TIMER does not send hours, it sends (at my device) only minutes and seconds. So all timers with > 23 minutes  fail in a "ValueError: hour must be in 0..23" because the assignment of hour, minute and second is wrong....May be this affects only my device....